### PR TITLE
Added test and fix for #5

### DIFF
--- a/src/main/scala/edu/oregonstate/mutation/statementHistory/NodeChangeDetector.scala
+++ b/src/main/scala/edu/oregonstate/mutation/statementHistory/NodeChangeDetector.scala
@@ -149,4 +149,5 @@ class NodeChangeDetector(private val git: Git, private val finder: NodeFinder) {
     walk.setFilter(PathSuffixFilter.create(path))
     walk.next()
     walk.getPathString
+  }
 }

--- a/src/main/scala/edu/oregonstate/mutation/statementHistory/NodeChangeDetector.scala
+++ b/src/main/scala/edu/oregonstate/mutation/statementHistory/NodeChangeDetector.scala
@@ -9,6 +9,8 @@ import fr.labri.gumtree.matchers.MappingStore
 import org.eclipse.jdt.core.dom.{ASTNode, CompilationUnit}
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.treewalk.TreeWalk
+import org.eclipse.jgit.treewalk.filter.PathSuffixFilter
 
 import scala.collection.JavaConversions
 
@@ -140,9 +142,11 @@ class NodeChangeDetector(private val git: Git, private val finder: NodeFinder) {
   }
 
   private def findFullPath(commit: RevCommit, path: String): String = {
-    val diffs = GitUtil.getDiffs(git, commit)
-    diffs.filter(diff => {
-      diff.getNewPath.endsWith(path)
-    })(0).getNewPath
-  }
+    val tree = commit.getTree
+    val walk = new TreeWalk(git.getRepository)
+    walk.addTree(tree)
+    walk.setRecursive(true)
+    walk.setFilter(PathSuffixFilter.create(path))
+    walk.next()
+    walk.getPathString
 }

--- a/src/test/scala/edu/oregonstate/mutation/statementHistory/StatementChangeDetectorTest.scala
+++ b/src/test/scala/edu/oregonstate/mutation/statementHistory/StatementChangeDetectorTest.scala
@@ -182,4 +182,13 @@ class StatementChangeDetectorTest extends GitTest {
     commits should have size (expected.size)
     commits should equal (expected)
   }
+
+  it should "not throw an NPE when the file wasn't modified in the reference commit" in {
+    val first = add("A.java", "public class A{\npublic void m(){\nint x=3;\n}\n}")
+    val second = add("B.java", "public class B{}")
+    git.rm().addFilepattern("A.java").call()
+    val third = git.commit().setMessage("smth").call()
+
+    val commits = nd(git).findCommits("A.java", 3, third.getName, Order.BOTH)
+  }
 }


### PR DESCRIPTION
It happens when the file is removed and then somebody
tries to reference it. Now, I use the whole tree and not
just the diff, so it should be fine.

Fixes #5
